### PR TITLE
Topic

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -4,12 +4,12 @@
     <meta charset="utf-8">
   </head>
   <body>
-    <div data-prop="counter" data-component>
+    <div data-prop="counter" data-topic="counter">
       <span data-prop="count">0</span>
     </div>
-    <span data-prop="count" data-component>0</span>
+    <span data-prop="count" data-topic="count">0</span>
     <div>
-      <article data-prop="post" data-component>
+      <article data-prop="post" data-topic="post">
         <!-- this is a post -->
         <h2 data-prop="title">title</h2>
         <p data-prop="body">body</p>
@@ -18,7 +18,7 @@
 
     <hr>
 
-    <div data-prop="post" data-component>
+    <div data-prop="post" data-topic="post">
       <h1 data-prop="title">title</h1>
       <p><strong data-prop="body">body</strong></p>
     </div>

--- a/lib/jank.js
+++ b/lib/jank.js
@@ -27,7 +27,7 @@ var Jank = {
     grouped.forEach((group) => {
       var template = group.elements[0];
       var wrapper = wrap(group.elements);
-      var channel = channelInit(group.kind);
+      var channel = channelInit(group.topic);
       var component = createComponent(template, channel);
 
       if (data) {

--- a/lib/jank.js
+++ b/lib/jank.js
@@ -24,10 +24,13 @@ var Jank = {
       return groups;
     }, new ElementGroups());
 
+    var channels = {};
+
     grouped.forEach((group) => {
       var template = group.elements[0];
       var wrapper = wrap(group.elements);
-      var channel = channelInit(group.topic);
+      var topic = group.topic;
+      var channel = channels[topic] = channels[topic] || channelInit(topic);
       var component = createComponent(template, channel);
 
       if (data) {

--- a/lib/jank.js
+++ b/lib/jank.js
@@ -17,7 +17,7 @@ var Jank = {
 
     // Note: This will fail as is when no existing data is in the view, because in
     // that case no view will be present at all.
-    var components = document.querySelectorAll('[data-component]');
+    var components = document.querySelectorAll('[data-topic]');
 
     var grouped = Array.prototype.reduce.call(components, function(groups, comp) {
       groups.add(comp)

--- a/lib/jank.js
+++ b/lib/jank.js
@@ -28,7 +28,7 @@ var Jank = {
       var template = group.elements[0];
       var wrapper = wrap(group.elements);
       var channel = channelInit(group.kind);
-      var component = createComponent(template, group.kind, channel);
+      var component = createComponent(template, channel);
 
       if (data) {
         ReactDOM.render(React.createElement(component, {data: data}), wrapper);

--- a/lib/jank/adapters/phoenix.js
+++ b/lib/jank/adapters/phoenix.js
@@ -1,10 +1,12 @@
+var dataEvent = 'data';
+
 function Phoenix(channel) {
   this.channel = channel;
   var callbacks = this.initCallbacks = [];
 
   var onMessage = this.channel.onMessage;
   this.channel.onMessage = function(event, payload, ref) {
-    if (event == 'data') {
+    if (event == dataEvent) {
       callbacks.forEach(function(cb) { cb(payload) });
       this.onMessage = onMessage;
     }
@@ -17,7 +19,7 @@ Phoenix.prototype.init = function(callback) {
 }
 
 Phoenix.prototype.data = function(callback) {
-  this.channel.on('data', callback);
+  this.channel.on(dataEvent, callback);
 }
 
 module.exports = Phoenix;

--- a/lib/jank/component.js
+++ b/lib/jank/component.js
@@ -8,7 +8,7 @@ function createElement(element) {
   return React.createElement.apply(undefined, [tag, props].concat(content));
 }
 
-function createComponent(template, name, channel) {
+function createComponent(template, channel) {
   return React.createClass({
     getInitialState: function() {
       return {data: this.props.data};

--- a/lib/jank/grouping.js
+++ b/lib/jank/grouping.js
@@ -1,32 +1,32 @@
 var equal = require('array-equal');
 
-var Group = function(kind, ancestor) {
-  this.kind = kind;
+var Group = function(topic, ancestor) {
+  this.topic = topic;
   this.ancestor = ancestor;
   this.elements = [];
 };
 
 Group.prototype.add = function(element) { this.elements.push(element) };
 
-Group.prototype.is = function(kind, ancestor) {
-  return this.kind == kind && this.ancestor == ancestor;
+Group.prototype.is = function(topic, ancestor) {
+  return this.topic == topic && this.ancestor == ancestor;
 };
 
 var ElementGroups = Array.prototype.constructor;
 
 ElementGroups.prototype.add = function(element) {
-  var kind = element.attributes.getNamedItem('data-prop').value;
+  var topic = element.attributes.getNamedItem('data-topic').value;
   var parent = element.parentNode;
-  var group = this.get(kind, parent) || this.create(kind, parent);
+  var group = this.get(topic, parent) || this.create(topic, parent);
   group.add(element);
 };
 
-ElementGroups.prototype.get = function(kind, parent) {
-  return this.find(function(g) { if (g.is(kind, parent)) { return g } });
+ElementGroups.prototype.get = function(topic, parent) {
+  return this.find(function(g) { if (g.is(topic, parent)) { return g } });
 };
 
-ElementGroups.prototype.create = function(kind, parent) {
-  var group = new Group(kind, parent);
+ElementGroups.prototype.create = function(topic, parent) {
+  var group = new Group(topic, parent);
   this.push(group);
   return group;
 };

--- a/test/grouping-test.js
+++ b/test/grouping-test.js
@@ -8,7 +8,7 @@ describe('grouping', () => {
     it('groups nodes by their kind and parent', () => {
       var parent1 = new Node();
       var parent2 = new Node();
-      var attr = new Attribute('data-prop', 'lol');
+      var attr = new Attribute('data-topic', 'lol');
       var node1 = new Node('div', [attr]);
       node1.parentNode = parent1;
       var node2 = new Node('div', [attr]);
@@ -21,9 +21,9 @@ describe('grouping', () => {
 
       expect(groups.length).to.eql(2);
 
-      expect(groups[0].kind).to.eql('lol');
+      expect(groups[0].topic).to.eql('lol');
       expect(groups[0].elements).to.eql([node1, node1]);
-      expect(groups[1].kind).to.eql('lol');
+      expect(groups[1].topic).to.eql('lol');
       expect(groups[1].elements).to.eql([node2]);
     });
   });


### PR DESCRIPTION
Up to this point channels have been subscribed to using the top-level `data-prop` on a "component". This doesn't really stand up to the test of time. Namely data topics need more details when the component data is scoped in some way, e.g. "this component shows comments for the post with id `123`". To that end, a mechanism is needed to communicate with the tool what data stream to subscribe to. This also becomes a grouping mechanism for channel initialization itself.
